### PR TITLE
feat: simple HTML home page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.html]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # directories
-build
 dist
 node_modules
 
@@ -8,6 +7,7 @@ node_modules
 *.log
 .DS_Store
 .pnp.*
+build/**/*.json
 package-lock.json
 pnpm-lock.yaml
 yarn.lock

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 # directories
-build
 node_modules
 
 # files
@@ -7,6 +6,7 @@ node_modules
 *.log
 .DS_Store
 .pnp.*
+build/**/*.json
 bun.lockb
 package-lock.json
 pnpm-lock.yaml

--- a/build/index.html
+++ b/build/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Sablier EVM Token List</title>
+        <style>
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+                    "Open Sans", "Helvetica Neue", sans-serif;
+                line-height: 1.6;
+                color: #333;
+                max-width: 650px;
+                margin: 0 auto;
+                padding: 2rem;
+                background-color: #f9f9f9;
+            }
+            .container {
+                background-color: white;
+                border-radius: 8px;
+                padding: 2rem;
+                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            }
+            h1 {
+                color: #2d3748;
+                margin-top: 0;
+                font-weight: 700;
+            }
+            p {
+                margin-bottom: 1.5rem;
+            }
+            .link-container {
+                background-color: #f7fafc;
+                border-left: 4px solid #4299e1;
+                padding: 1rem;
+                border-radius: 4px;
+                margin: 1.5rem 0;
+            }
+            a {
+                color: #3182ce;
+                text-decoration: none;
+                font-weight: 500;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+            .footer {
+                margin-top: 2rem;
+                font-size: 0.875rem;
+                color: #718096;
+                text-align: center;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h1>Sablier EVM Token List</h1>
+
+            <p>This website serves as a host for the Sablier EVM Token List JSON file.</p>
+
+            <div class="link-container">
+                <p>The tokenlist is available at:</p>
+                <a href="/sablier-evm.tokenlist.json">/sablier-evm.tokenlist.json</a>
+            </div>
+
+            <p>This file contains token information used by Sablier and other applications on EVM chains.</p>
+
+            <div class="link-container">
+                <p>View the source code on GitHub:</p>
+                <a href="https://github.com/sablier-labs/evm-token-list" target="_blank"
+                    >github.com/sablier-labs/evm-token-list</a
+                >
+            </div>
+
+            <div class="footer">Hosted on Vercel</div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This PR adds a simple home page in `build/index.html` so that Vercel will display a preview of the website and anyone stumbling upon `sablier-evm-token-list.vercel.app` will be able to immediately figure out what the website is about.

<img width="400" alt="SCR-20250307-ovoo" src="https://github.com/user-attachments/assets/1ca0ec5f-c9b7-4937-9f5e-84603b64b0a1" />

cc @sablier-labs/frontend 